### PR TITLE
v0.08.04.5 - next() call was accidental moved inside error hadling if…

### DIFF
--- a/invKeepBackend/routes/ratiosAnalysis.js
+++ b/invKeepBackend/routes/ratiosAnalysis.js
@@ -237,7 +237,6 @@ var uploadMiddleware = function (req, res, next) {
                     break;
 
                 default:
-
                     //  error if file heavier than 2 MB was uploaded
                     if (err.code === 'LIMIT_FILE_SIZE') {
                         res.status(413).json({
@@ -251,8 +250,8 @@ var uploadMiddleware = function (req, res, next) {
                         });
                     }
             }
-            next();
         }
+        next();
     });
 }
 


### PR DESCRIPTION
…, instead of remain at the end of multer middleware. So, instead of calling next() when there were no errors in file upload, it was called when the error was pressen. As a result, old file deletion or new one saving was not conducted - fixed here